### PR TITLE
fix "Cannot read property 'init' of undefined"

### DIFF
--- a/src/FreshdeskWidget.js
+++ b/src/FreshdeskWidget.js
@@ -6,6 +6,9 @@ require('./object-values-entries-polyfill');
 class FreshdeskWidget extends Component {
     constructor(props) {
         super(props);
+        this.state = {
+            freshdeskScriptLoaded: false
+        };
 
         this.renderPopUp = this.renderPopUp.bind(this);
         this.renderWithChildren = this.renderWithChildren.bind(this);
@@ -16,6 +19,7 @@ class FreshdeskWidget extends Component {
         const script = document.createElement('script');
         script.src = 'https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.js';
         script.type = 'text/javascript';
+        script.onload = () => { this.setState({freshdeskScriptLoaded: true}); };
         document.body.appendChild(script);
     }
 
@@ -168,6 +172,9 @@ class FreshdeskWidget extends Component {
     }
 
     render() {
+        if (!this.state.freshdeskScriptLoaded)
+            return null; // can't render anything before the script is loaded
+
         const { type } = this.props;
 
         if (type === 'incorporated') {


### PR DESCRIPTION
The issue is caused by the component calling Freshdesk widget API before the script is loaded.

This commit fixes that by adding `freshdeskScriptLoaded` state and rendering only once it is set.

It seems that this widget is now obsolete, as there is a newer script at freshdesk (https://developers.freshdesk.com/widget-api/) but as the old one still exists, maybe someone can still find that helpful.

For my usecase (type=pop-up) I also needed to invoke `window.FreshDesk.create()` after `window.FreshDesk.init()` -- or one could add `loadOnEvent: "immediate"` into the props passed to `FreshDesk.create()`. The default value of `loadOnEvent` is `"windowLoad"` which is a bit too late when the widget is rendered.

In my simple usecase (display a FreshDesk button and let FreshDesk handle the rest) I ended up with a bit simpler version: https://gist.github.com/zub2/2b705a2b4e1d3a991ae535a9b3157e63